### PR TITLE
Opportunity to fully setup student representative duties for non-super admins

### DIFF
--- a/app/Http/Controllers/Admin/DutyController.php
+++ b/app/Http/Controllers/Admin/DutyController.php
@@ -179,7 +179,8 @@ class DutyController extends ResourceController
         return redirect()->route('duties.index')->with('info', 'Pareigybė sėkmingai ištrinta!');
     }
 
-    public function setAsStudentRepresentatives(Request $request) {
+    public function setAsStudentRepresentatives(Request $request)
+    {
         $this->authorize('update', [Duty::class, $this->authorizer]);
 
         $request->validate([

--- a/app/Http/Controllers/Admin/DutyController.php
+++ b/app/Http/Controllers/Admin/DutyController.php
@@ -178,4 +178,22 @@ class DutyController extends ResourceController
 
         return redirect()->route('duties.index')->with('info', 'Pareigybė sėkmingai ištrinta!');
     }
+
+    public function setAsStudentRepresentatives(Request $request) {
+        $this->authorize('update', [Duty::class, $this->authorizer]);
+
+        $request->validate([
+            'duties' => 'required|array',
+        ]);
+
+        $duties = Duty::find($request->duties);
+
+        // attach student representative type and role to duties, but without duplication errors
+        foreach ($duties as $duty) {
+            $duty->types()->syncWithoutDetaching(Type::where('title', 'Studentų atstovas')->first());
+            $duty->roles()->syncWithoutDetaching(Role::where('name', 'Studentų atstovas')->first());
+        }
+
+        return back()->with('success', 'Pareigybės sėkmingai atnaujintos!');
+    }
 }

--- a/resources/js/Components/AdminForms/DutyForm.vue
+++ b/resources/js/Components/AdminForms/DutyForm.vue
@@ -110,7 +110,14 @@
       <FormElement>
         <template #title>Papildoma informacija</template>
         <template #description
-          >Šiuo metu šie nustatymai tik rodomi, jų negalima keisti...</template
+          ><p>
+            <strong>Pareigybės tipas</strong> reikalingas tam, kad tam tikrais atvejais, nariai būtų rodomi
+            viešame studentų atstovybės puslapyje. Pavyzdžiui, studentų
+            atstovo tipui priklausantys asmenys rodomi prie institucijos kontaktų.
+          </p>
+          <p><strong>Administracinė vusa.lt rolė</strong>leidžia registruotiems naudotojams atlikti jiems priskirtus veiksmus
+          vidiniame mano.vusa.lt tinklalapyje</p>
+          </template
         >
         <NFormItem label="Pareigybės tipas" :span="2">
           <NSelect

--- a/resources/js/Components/AdminForms/DutyForm.vue
+++ b/resources/js/Components/AdminForms/DutyForm.vue
@@ -110,16 +110,19 @@
       <FormElement>
         <template #title>Papildoma informacija</template>
         <template #description
-          ><p>
-            <strong>Pareigybės tipas</strong> reikalingas tam, kad tam tikrais atvejais, nariai būtų rodomi
-            viešame studentų atstovybės puslapyje. Pavyzdžiui, studentų
-            atstovo tipui priklausantys asmenys rodomi prie institucijos kontaktų.
-          </p>
-          <p><strong>Administracinė vusa.lt rolė</strong>leidžia registruotiems naudotojams atlikti jiems priskirtus veiksmus
-          vidiniame mano.vusa.lt tinklalapyje</p>
+          >
+          <div class="flex flex-col gap-2">
+            <p>
+              <strong>Pareigybės tipas</strong> reikalingas tam, kad tam tikrais atvejais, nariai būtų rodomi
+              viešame studentų atstovybės puslapyje. Pavyzdžiui, studentų
+              atstovo tipui priklausantys asmenys rodomi prie institucijos kontaktų.
+            </p>
+            <p><strong>Administracinė vusa.lt rolė </strong> leidžia registruotiems naudotojams atlikti jiems priskirtus veiksmus
+            vidiniame mano.vusa.lt tinklalapyje</p>
+          </div>
           </template
         >
-        <NFormItem label="Pareigybės tipas" :span="2">
+        <NFormItem label="Pareigybės tipas">
           <NSelect
             v-model:value="form.types"
             :disabled="!$page.props.auth.user.isSuperAdmin"
@@ -132,7 +135,7 @@
           />
         </NFormItem>
 
-        <NFormItem label="Administracinė vusa.lt rolė" :span="2">
+        <NFormItem label="Administracinė vusa.lt rolė">
           <NSelect
             v-model:value="form.roles"
             :disabled="!$page.props.auth.user.isSuperAdmin"

--- a/resources/js/Components/Layouts/IndexModel/IndexDataTable.vue
+++ b/resources/js/Components/Layouts/IndexModel/IndexDataTable.vue
@@ -89,7 +89,6 @@ const checkedRowKeys = inject<Ref<DataTableRowKey[]>>("checkedRowKeys", ref([]))
 
 const handleCheckedRowKeysChange = (rowKeys: DataTableRowKey[]) => {
   checkedRowKeys.value = rowKeys;
-  console.log(checkedRowKeys.value);
 };
 
 const handleChange = (page: number) => {

--- a/resources/js/Components/Layouts/IndexModel/IndexDataTable.vue
+++ b/resources/js/Components/Layouts/IndexModel/IndexDataTable.vue
@@ -11,11 +11,13 @@
     :columns="columnsWithActions"
     :loading="loading"
     :pagination="pagination"
+    :row-key="rowKey"
     pagination-behavior-on-filter="first"
     default-expand-all
     @update:sorter="handleSorterChange"
     @update:page="handleChange"
     @update:filters="handleFiltersChange"
+    @update-checked-row-keys="handleCheckedRowKeysChange"
   >
   </NDataTable>
 </template>
@@ -31,13 +33,15 @@ import {
   NDataTable,
   NIcon,
 } from "naive-ui";
-import { computed, inject, ref } from "vue";
+import { computed, inject, ref, type Ref } from "vue";
 import { router } from "@inertiajs/vue3";
-import type { DataTableColumns } from "naive-ui";
+import type { DataTableColumns, DataTableRowKey } from "naive-ui";
 
+import { updateFilters, updateSorters } from "@/Utils/DataTable";
 import { Link } from "@inertiajs/vue3";
 import DeleteModelButton from "@/Components/Buttons/DeleteModelButton.vue";
 import IndexSearchInput from "./IndexSearchInput.vue";
+import type { SortOrder } from "naive-ui/es/data-table/src/interface";
 
 const props = defineProps<{
   columns: DataTableColumns<Record<string, any>>;
@@ -49,8 +53,9 @@ const props = defineProps<{
 }>();
 
 const loading = ref(false);
-const { sorters, updateSorters } = inject("sorters", {});
-const { filters, updateFilters } = inject("filters", {});
+
+const sorters = inject<Ref<Record<string, SortOrder>> | undefined>("sorters", undefined);
+const filters = inject<Ref<Record<string, any>> | undefined>("filters", undefined);
 
 const pagination = ref({
   itemCount: props.paginatedModels.total,
@@ -60,14 +65,31 @@ const pagination = ref({
   showQuickJumper: true,
 });
 
-const handleFiltersChange = (state: DataTableFilterState) => {
-  filters.value = updateFilters(filters, state);
+const handleSorterChange = (state: DataTableSortState) => {
+
+  if (sorters !== undefined) {
+    sorters.value = updateSorters(sorters, state);
+  }
+
   handleChange(1);
 };
 
-const handleSorterChange = (state: DataTableSortState) => {
-  sorters.value = updateSorters(sorters, state);
+const handleFiltersChange = (state: DataTableFilterState) => {
+
+  if (filters !== undefined) {
+    filters.value = updateFilters(filters, state);
+  }
+
   handleChange(1);
+};
+
+const rowKey = (row: Record<string, any>) => row.id;
+
+const checkedRowKeys = inject<Ref<DataTableRowKey[]>>("checkedRowKeys", ref([]));
+
+const handleCheckedRowKeysChange = (rowKeys: DataTableRowKey[]) => {
+  checkedRowKeys.value = rowKeys;
+  console.log(checkedRowKeys.value);
 };
 
 const handleChange = (page: number) => {
@@ -100,8 +122,16 @@ const handleChange = (page: number) => {
 const handleCompletedSearch = () => handleChange(1);
 
 const sweepSearch = () => {
-  updateFilters(filters, undefined);
-  updateSorters(sorters, undefined);
+
+  if (filters !== undefined) {
+    filters.value = updateFilters(filters, undefined);
+  }
+
+  if (sorters !== undefined) {
+    sorters.value = updateSorters(sorters, undefined);
+  }
+
+  handleCheckedRowKeysChange([]);
 
   router.reload({
     data: { page: 1, filters: undefined, sorters: undefined, text: undefined },

--- a/resources/js/Pages/Admin/People/IndexDuty.vue
+++ b/resources/js/Pages/Admin/People/IndexDuty.vue
@@ -11,10 +11,12 @@
 </template>
 
 <script setup lang="tsx">
-import { NButton, NEllipsis, NIcon } from "naive-ui";
+import { NButton, NEllipsis, NIcon, type DataTableRowKey, type DataTableColumns } from "naive-ui";
 
 import Icons from "@/Types/Icons/regular";
 import IndexPageLayout from "@/Components/Layouts/IndexModel/IndexPageLayout.vue";
+import { provide, ref } from "vue";
+import { router } from "@inertiajs/vue3";
 
 defineProps<{
   duties: PaginatedModels<App.Entities.Duty>;
@@ -27,7 +29,28 @@ const canUseRoutes = {
   destroy: false,
 };
 
-const columns = [
+const checkedRowKeys = ref<DataTableRowKey[]>([])
+
+provide("checkedRowKeys", checkedRowKeys);
+
+const columns: DataTableColumns<App.Entities.Duty> = [
+  {
+    type: 'selection',
+    options: [
+          'all',
+          'none',
+          {
+            label: 'Set as student representatives',
+            key: 'set-as-student-representatives',
+            onSelect: (rows) => {
+              router.put(route('duties.setAsStudentRepresentatives'), {
+                duties: checkedRowKeys.value
+              })
+            }
+          }
+        ],
+    width: 50,
+  },
   {
     title: "Pavadinimas",
     key: "name",

--- a/resources/js/Pages/Admin/People/IndexInstitution.vue
+++ b/resources/js/Pages/Admin/People/IndexInstitution.vue
@@ -21,7 +21,6 @@ import { computed, provide, ref } from "vue";
 import { usePage } from "@inertiajs/vue3";
 
 import { formatStaticTime } from "@/Utils/IntlTime";
-import { updateFilters, updateSorters } from "@/Utils/DataTable";
 import Icons from "@/Types/Icons/regular";
 import IndexPageLayout from "@/Components/Layouts/IndexModel/IndexPageLayout.vue";
 import ModelChip from "@/Components/Chips/ModelChip.vue";
@@ -42,13 +41,13 @@ const sorters = ref<Record<string, DataTableSortState["order"]>>({
   name: false,
 });
 
-provide("sorters", { sorters, updateSorters });
+provide("sorters", sorters);
 
 const filters = ref<Record<string, any>>({
   "padalinys.id": [],
 });
 
-provide("filters", { filters, updateFilters });
+provide("filters", filters);
 
 const columns = computed<DataTableColumns<App.Entities.Institution>>(() => {
   return [

--- a/resources/js/Pages/Admin/People/IndexUser.vue
+++ b/resources/js/Pages/Admin/People/IndexUser.vue
@@ -27,7 +27,7 @@ const sorters = ref<Record<string, DataTableSortState["order"]>>({
   name: false,
 });
 
-provide("sorters", { sorters, updateSorters });
+provide("sorters", sorters);
 
 const canUseRoutes = {
   create: true,

--- a/resources/js/Pages/Admin/Representation/IndexMeeting.vue
+++ b/resources/js/Pages/Admin/Representation/IndexMeeting.vue
@@ -35,13 +35,13 @@ const sorters = ref<Record<string, DataTableSortState["order"]>>({
   start_time: "descend",
 });
 
-provide("sorters", { sorters, updateSorters });
+provide("sorters", sorters);
 
 const filters = ref<Record<string, any>>({
   padaliniai: [],
 });
 
-provide("filters", { filters, updateFilters });
+provide("filters", filters);
 
 const columns = computed<DataTableColumns<App.Entities.Meeting>>(() => {
   return [

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -49,10 +49,12 @@ Route::resource('saziningaiExams', SaziningaiExamsController::class);
 Route::resource('saziningaiExamFlows', SaziningaiExamFlowsController::class);
 Route::resource('saziningaiExamObservers', SaziningaiExamObserversController::class);
 Route::resource('files', FilesController::class);
+
+Route::put('duties/setAsStudentRepresentatives', [DutyController::class, 'setAsStudentRepresentatives'])->name('duties.setAsStudentRepresentatives');
 Route::resource('duties', DutyController::class);
 Route::resource('duties.users', DutiableController::class);
-Route::resource('institutions', InstitutionController::class);
 Route::post('institutions/reorderDuties', [InstitutionController::class, 'reorderDuties'])->name('institutions.reorderDuties');
+Route::resource('institutions', InstitutionController::class);
 
 Route::resource('types', TypeController::class);
 Route::resource('relationships', RelationshipController::class);

--- a/routes/web.php
+++ b/routes/web.php
@@ -54,7 +54,7 @@ Route::group(['prefix' => '{lang?}', 'where' => ['lang' => 'lt|en'], 'middleware
         Route::redirect('/admin', '/mano', 301);
 
         Route::get('/apgyvendinimas', function () {
-            return Redirect::to(config('app.url') . '/lt/bendrabuciai', 301);
+            return Redirect::to(config('app.url').'/lt/bendrabuciai', 301);
         });
 
         Route::get('kontaktai', [Public\ContactController::class, 'contacts'])->name('contacts');


### PR DESCRIPTION
This makes it possible for anyone with viewAll permissions to set the Duty type and administrative role of selected Duties as student representatives.

The feature is temporary, used to solve one case of permission management and is available through the duty index page. Other permission management features may be considered in the future.

<img width="545" alt="image" src="https://github.com/vu-sa/vusa.lt/assets/23059846/e4679b9e-8651-4197-ab77-ae4ec8771b76">

Also, fixed issue where the search sweep wasn't working for tables, which don't have filters or sorters.
