### PR TITLE
Fix event card bad response

### DIFF
--- a/app/Models/Traits/HasTasks.php
+++ b/app/Models/Traits/HasTasks.php
@@ -13,7 +13,7 @@ trait HasTasks
         return $this->morphMany(Task::class, 'taskable');
     }
 
-    public function storeTask(string $name, Collection $users, ?string $due_date = null)
+    public function storeTask(string $name, Collection $users, string $due_date = null)
     {
         $task = TaskService::storeTask($name, $this, $users, $due_date);
 

--- a/app/Services/ModelIndexer.php
+++ b/app/Services/ModelIndexer.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Auth;
 class ModelIndexer
 {
     // check argument to be class of model
-    public function execute(string $modelClass, string|null $search, string $searchable, Authorizer $authorizer, bool|null $hasManyPadalinys = true): Builder
+    public function execute(string $modelClass, ?string $search, string $searchable, Authorizer $authorizer, ?bool $hasManyPadalinys = true): Builder
     {
         if (! class_exists($modelClass)) {
             // return exception that the class doesn't exist

--- a/app/Services/SharepointGraphService.php
+++ b/app/Services/SharepointGraphService.php
@@ -34,7 +34,7 @@ class SharepointGraphService
      * @param  mixed  $driveId
      * @return void
      */
-    public function __construct(?string $siteId = null, ?string $driveId = null)
+    public function __construct(string $siteId = null, string $driveId = null)
     {
         if (Cache::has('ms_application_token')) {
             $token = Crypt::decryptString(Cache::get('ms_application_token'));

--- a/app/Services/TaskService.php
+++ b/app/Services/TaskService.php
@@ -10,7 +10,7 @@ class TaskService
 {
     // * Create tasks for users, when creating a doing with meeting type
 
-    public static function storeTask(string $name, Model $model, Collection $users, ?string $due_date = null)
+    public static function storeTask(string $name, Model $model, Collection $users, string $due_date = null)
     {
         $task = Task::create([
             'name' => $name,

--- a/resources/js/Components/Public/FullWidth/EventCalendarElement.vue
+++ b/resources/js/Components/Public/FullWidth/EventCalendarElement.vue
@@ -92,7 +92,7 @@
   >
     <h2 class="text-center lg:text-start">Artėjantys renginiai</h2>
     <div class="mx-auto my-8 flex w-fit flex-wrap gap-4 lg:mx-0">
-      <Link
+      <a
         v-for="event in upcoming4Events"
         :key="event.id"
         class="h-fit w-fit"
@@ -104,13 +104,13 @@
         "
       >
         <CalendarCard :calendar-event="event" />
-      </Link>
+      </a>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
-import { Head, Link } from "@inertiajs/vue3";
+import { Head } from "@inertiajs/vue3";
 import { NButton, NMessageProvider } from "naive-ui";
 import { ref } from "vue";
 


### PR DESCRIPTION
When using a calendar card link in a padalinys domain, there was an error, because padaliniai in general don't have routes to calendar events.

In the future, we could transfer the "calendar.event" to the padaliniai routes, but all the routes may need to be changed in the components, so right now this will be the solution.