### PR TITLE
Change default notification email

### DIFF
--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -2,25 +2,10 @@
 
 namespace App\Models;
 
+use App\Models\Traits\HasUnitRelation;
 use Illuminate\Database\Eloquent\Model as EloquentModel;
 
 class Model extends EloquentModel
 {
-    // * The problem is that some models have different method names for getting the unit relation
-    // * This returns the method name for the unit relation
-    public function whichUnitRelation()
-    {
-        // check for padalinys relation
-        if (method_exists($this, 'padalinys')) {
-            return 'padalinys';
-        }
-
-        // check for padaliniai relation
-        if (method_exists($this, 'padaliniai')) {
-            return 'padaliniai';
-        }
-
-        // throw exception if no unit relation found
-        throw new \Exception('No unit relation found');
-    }
+    use HasUnitRelation;
 }

--- a/app/Models/Traits/HasUnitRelation.php
+++ b/app/Models/Traits/HasUnitRelation.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models\Traits;
+
+trait HasUnitRelation
+{
+    /**
+     * Returns the method name for the unit relation.
+     * The problem is that some models have different method names for getting the unit relation
+     * It's better if user is extended from Authenticatable, not from Model, because impersonate package throws errors
+     */
+    public function whichUnitRelation(): string
+    {
+        // check for padalinys relation
+        if (method_exists($this, 'padalinys')) {
+            return 'padalinys';
+        }
+
+        // check for padaliniai relation
+        if (method_exists($this, 'padaliniai')) {
+            return 'padaliniai';
+        }
+
+        // Throw exception if no unit relation found.
+        throw new \Exception('No unit relation found');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -67,19 +67,17 @@ class User extends Authenticatable
     {
         $authorization->impersonator(fn (User $user) => $user->hasRole(config('permission.super_admin_role_name')));
 
-        $authorization->impersonated(fn (User $user) => !$user->hasRole(config('permission.super_admin_role_name')));
+        $authorization->impersonated(fn (User $user) => ! $user->hasRole(config('permission.super_admin_role_name')));
     }
 
     /**
-     * 
      * If the user has a duty, always send to current_duties if duty email ends with vusa.lt
      * More on this: https://laravel.com/docs/10.x/notifications#customizing-the-recipient
      * TODO: it is not really optimal as sometimes notifications should be sent directly to user
      *
      * @param Notification notification
-     * @return array | string
      */
-    public function routeNotificationForMail(Notification $notification): array | string
+    public function routeNotificationForMail(Notification $notification): array|string
     {
         // If the user has a duty, always send to current_duties if duty email ends with vusa.lt
         // More on this: https://laravel.com/docs/10.x/notifications#customizing-the-recipient

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Models\Pivots\Dutiable;
+use App\Models\Traits\HasUnitRelation;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -19,7 +20,7 @@ use Staudenmeir\EloquentHasManyDeep\HasRelationships;
 
 class User extends Authenticatable
 {
-    use HasFactory, HasRelationships, HasRoles, HasUlids, Impersonate, LogsActivity, Notifiable, Searchable, SoftDeletes;
+    use HasFactory, HasRelationships, HasRoles, HasUlids, HasUnitRelation, Impersonate, LogsActivity, Notifiable, Searchable, SoftDeletes;
 
     /**
      * The attributes that are mass assignable.
@@ -74,14 +75,9 @@ class User extends Authenticatable
      * If the user has a duty, always send to current_duties if duty email ends with vusa.lt
      * More on this: https://laravel.com/docs/10.x/notifications#customizing-the-recipient
      * TODO: it is not really optimal as sometimes notifications should be sent directly to user
-     *
-     * @param Notification notification
      */
     public function routeNotificationForMail(Notification $notification): array|string
     {
-        // If the user has a duty, always send to current_duties if duty email ends with vusa.lt
-        // More on this: https://laravel.com/docs/10.x/notifications#customizing-the-recipient
-        // TODO: it is not really optimal as sometimes notifications should be sent directly to user
         if ($this->current_duties()->count() > 0) {
             foreach ($this->current_duties()->get() as $duty) {
                 if (str_ends_with($duty->email, 'vusa.lt')) {
@@ -91,25 +87,6 @@ class User extends Authenticatable
         }
 
         return $this->email;
-    }
-
-    // * The problem is that some models have different method names for getting the unit relation
-    // * This returns the method name for the unit relation
-    // ! It's better if user is extended from Authenticatable, not from Model, because impersonate package throws errors
-    public function whichUnitRelation()
-    {
-        // check for padalinys relation
-        if (method_exists($this, 'padalinys')) {
-            return 'padalinys';
-        }
-
-        // check for padaliniai relation
-        if (method_exists($this, 'padaliniai')) {
-            return 'padaliniai';
-        }
-
-        // throw exception if no unit relation found
-        throw new \Exception('No unit relation found');
     }
 
     public function banners()

--- a/resources/js/Pages/Admin/Reservations/IndexReservation.vue
+++ b/resources/js/Pages/Admin/Reservations/IndexReservation.vue
@@ -1,20 +1,11 @@
 <template>
-  <IndexPageLayout
-    :title="capitalize($tChoice('entities.reservation.model', 2))"
-    model-name="reservations"
-    :icon="Icons.RESERVATION"
-    :can-use-routes="canUseRoutes"
-    :columns="columns"
-    :paginated-models="reservations"
-  >
+  <IndexPageLayout :title="capitalize($tChoice('entities.reservation.model', 2))" model-name="reservations"
+    :icon="Icons.RESERVATION" :can-use-routes="canUseRoutes" :columns="columns" :paginated-models="reservations">
     <NCard class="mb-4">
-      <template #header>{{ $t("Reservations with unit resources") }}</template>
-      <NDataTable
-        :columns="columnsWithActions"
-        :data="activeReservations"
-        size="small"
-        :row-key="(row) => row.id"
-      ></NDataTable>
+      <template #header>
+        {{ $t("Reservations with unit resources") }}
+      </template>
+      <NDataTable :columns="columnsWithActions" :data="activeReservations" size="small" :row-key="(row) => row.id" />
     </NCard>
   </IndexPageLayout>
 </template>
@@ -189,20 +180,13 @@ const columnsWithActions = computed(() => {
       width: 100,
       render(row) {
         return (
-          <div class="flex justify-center">
-            <NButton
-              quaternary
-              class="text-gray-500 hover:text-gray-700"
-              size="small"
-              onClick={() => {
-                route("reservations.show", row.id);
-              }}
-            >
+          <Link href={route("reservations.show", row.id)} >
+            <NButton quaternary size="small">
               <NIcon>
                 <ArrowForward20Filled />
               </NIcon>
             </NButton>
-          </div>
+          </Link>
         );
       },
     },

--- a/tests/Feature/Notifications/CommentNotificationTest.php
+++ b/tests/Feature/Notifications/CommentNotificationTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature\Notifications;
 use App\Events\CommentPosted;
 use App\Models\Comment;
 use App\Models\Doing;
+use App\Models\Duty;
 use App\Models\User;
 use App\Notifications\ModelCommented;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -33,6 +34,32 @@ class CommentNotificationTest extends TestCase
 
         Notification::assertSentTo(
             [$user],
+            ModelCommented::class
+        );
+    }
+
+    // Test if comment notification is sent to duty email if user has current_duty with email vusa.lt
+    // For doings it's not as applicable as for reservations and other models
+    public function test_asserts_that_a_comment_notification_is_sent_to_duty_email_if_user_has_current_duty_with_email_vusa_lt()
+    {
+        $user = User::factory()->hasAttached(
+            Duty::factory()->count(1)->state(
+                fn () => ['email' => 'example@vusa.lt']
+            ),
+            ['start_date' => now()]
+        )->create();
+
+        $doing = Doing::factory()->hasAttached($user)->create();
+        // get user from doing
+
+        $comment = Comment::factory()->for($user)->for($doing, 'commentable')->create();
+
+        Notification::fake();
+
+        CommentPosted::dispatch($comment);
+
+        Notification::assertSentTo(
+            [$user->current_duties()->first()],
             ModelCommented::class
         );
     }


### PR DESCRIPTION
- Default notification mail is the first 'vusa.lt' containing email
- Fix a button in the reservation index page
- Add a trait HasUnitRelation (to not repeat some code)

In the future a better option may be developed, to set the preference for notification, when creating it (although a review of all notifications is needed at first)