### PR TITLE
Added document redaction page to docs

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -23,7 +23,8 @@ export default defineConfig({
             items: [
               { text: 'Funkcijos', link: '/visak' },
               { text: 'Atsakomybės', link: '/atsakomybes/studentu-atstovams' },
-              { text: 'D.U.K.', link: '/faq' }
+              { text: 'D.U.K.', link: '/faq' },
+              { text: 'Dokumentų nuasmeninimas', link: '/dng'}
             ]
           },
           {

--- a/docs/dng.md
+++ b/docs/dng.md
@@ -1,4 +1,4 @@
-# Dokumentų Nuasmeninimas
+# Dokumentų nuasmeninimas
 
 ## Esminiai terminai
 - **Darinys** – KAP AEK, KAP GNK, KAP PAK ir kitos institucijos, įskaitant ir laikinų darbo grupių, kurių nariai yra pasirašę VU rektoriaus ar jo įgalioto asmens nustatytos formos konfidencialumo pasižadėjimą ir nešališkumo deklaraciją. 

--- a/docs/dng.md
+++ b/docs/dng.md
@@ -1,0 +1,55 @@
+# Dokumentų Nuasmeninimas
+
+## Esminiai terminai
+- **Darinys** – KAP AEK, KAP GNK, KAP PAK ir kitos institucijos, įskaitant ir laikinų darbo grupių, kurių nariai yra pasirašę VU rektoriaus ar jo įgalioto asmens nustatytos formos konfidencialumo pasižadėjimą ir nešališkumo deklaraciją. 
+- **Esminiai duomenys** – būtina informacija dokumento turiniui perteikti. 
+- **Jautrūs duomenys** – duomenys, leidžiantys identifikuoti asmenį. 
+- **Neskelbtini duomenys** – konfidencialūs duomenys, tokie kaip politinės pažiūros ar sveikatos informacija.
+
+## Kas yra dokumentų nuasmeninimas?
+**Nuasmeninimas** – metodas, siekiantis pašalinti asmens tapatybės nustatymo galimybę iš dokumentų paliekant esminius duomenis. Nuasmeninimo taikymas yra svarbus, nes tai padeda organizacijai atitikti galiojančius Lietuvos bei ES duomenų apsaugos įstatymus. 
+
+## Kokius dokumentus rekomenduojama nuasmeninti? 
+- Darinių posėdžių ataskaitas 
+- Darinių posėdžių protokolus 
+- Kitus dokumentus, vadovaujantis protingumo principu 
+
+## Kokie duomenys laikomi jautriais ar *neskelbtinais*? 
+**Pastaba:** neskelbtini duomenys yra pažymėti pasvirai. Šių duomenų nuasmeninimui turi būti taikomas išskirtinis prioritetas.
+- Vardas, pavardė 
+- Telefono numeris, el. pašto adresas 
+- Nuotrauka ar vaizdo įrašas 
+- Adresas, banko sąskaitos numeris 
+- Socialinių tinklų informacija 
+- *Rasinė ar etninė kilmė*
+- *Politinės pažiūros*
+- *Religiniai ar filosofiniai įsitikinimai*
+- *Narystė profesinėse sąjungose*
+- *Sveikatos duomenys*
+- *Lytinė orientacija*
+
+## Kokie yra pagrindiniai nuasmeninimo metodai? 
+-   **Iškraipytų duomenų įterpimas** – duomenų tikslumo mažinimas išlaikant kontekstą. 
+    - **Pvz.:** Jei studentas gavo 93 balus, galima rašyti „studentas gavo apie 90 balų“. 
+-   **Apibendrinimas** – informacijos pateikimas platesniu mastu. 
+    - **Pvz.:** Jei studentas mokosi Vilniaus universiteto Filologijos fakultete, galima nurodyti tik Vilniaus universitete“. 
+-   **Pseudonimų suteikimas** – duomenų pakeitimas unikaliu kodu. 
+    - **Pvz.:** Vietoj „Jonas Petraitis“ rašyti „Studentas S1“. 
+
+## Kada būtina taikyti nuasmeninimą? 
+-  Kai dokumente yra ne Darinio narių asmens duomenų (pvz. pareiškėjo, atsakovo, ekspertų komisijos narių ir pan.).
+-  Kai yra jautrūs arba neskelbtini duomenys. 
+-  Kai duomenų atskleidimas gali kelti privatumo riziką. 
+
+## Kaip vertinama atskleidimo rizika? 
+- **Išskyrimo galimybė** – ar konkretus asmuo gali būti identifikuotas iš unikalių duomenų? 
+    - **Pvz.:** „Iš miesto X esantis studentas gavo vardinę stipendiją“ – jei toks studentas yra vienintelis, jo tapatybę galima atsekti. 
+- **Susiejimo galimybė** – ar galima sujungti skirtingus duomenų šaltinius tapatybei nustatyti
+    - **Pvz.:** „Studentas studijuoja biochemiją ir yra kuratorius“ – jei tik vienas studentas atitinka šias sąlygas, jį galima identifikuoti. 
+- **Išvados padarymo galimybė** – ar galima daryti logiškas išvadas apie asmenį iš pateiktos informacijos? 
+    - **Pvz.:** „Studentas yra pirmakursis ir gyvena bendrabutyje, kuriame gyvena tik X fakulteto studentai“ – galima nustatyti jo fakultetą.
+- **Mozaikos efektas** – ar viešai prieinama informacija leidžia nustatyti tapatybę? 
+    - **Pvz.:** Jei dokumente nurodoma, kad studentas laimėjo konkursą, o konkurso rezultatai viešai skelbiami, galima identifikuoti studentą. 
+
+## Daugiau informacijos
+- [VU SA dokumentų nuasmeninimo gairės](https://vustudentuatstovybe.sharepoint.com/:b:/s/vieningai/Efk_mLzwG7hNj3Ia3o1qFAcBSY3ZegSGJ1xEt01yJIApOQ)


### PR DESCRIPTION
The PR does two changes:
1. Edits sidebar to include a link to „Dokumentų nuasmeninimas“ _(eng. "Document redaction")_ page
2. Added a post to `docs/dng.md`, which provides a summary of „Dokumentų Nuasmeninimo Gairės“ _(eng. Document Redaction Guidelines)_ and links to it.

Additional credit to [Alchemija](https://github.com/alchemija) for helping with the creation of the document and the blog post :pray: 