### PR TITLE
Fix start_time and deploy issue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Build docs
         run: |
           npm run docs:build
-          tar -czf docs.tar.gz -C docs/.vitepress/dist .
+          tar -czf docs.tar.gz -C public/docs .
           
       # Deploy to server
       - name: Upload and run on server

--- a/resources/js/Components/AdminForms/MeetingForm.vue
+++ b/resources/js/Components/AdminForms/MeetingForm.vue
@@ -154,8 +154,15 @@ const onSubmit = (values) => {
   // Time is required so should always be present at this point
   dt.setHours(values.time.hour, values.time.minute);
   
+  // Format date in local timezone without conversion to UTC
+  // This formats as YYYY-MM-DDTHH:mm:ss.sss in local timezone
+  const localISOString = new Date(dt.getTime() - (dt.getTimezoneOffset() * 60000))
+    .toISOString()
+    .slice(0, 19)
+    .replace('T', ' ');
+  
   const formData = {
-    start_time: dt.toISOString(),
+    start_time: localISOString,
     type_id: values.type_id,
   };
   


### PR DESCRIPTION
This pull request includes changes to improve file handling during documentation deployment and to ensure date formatting aligns with the local timezone in the meeting form. Below are the most important changes grouped by theme:

### Documentation Deployment:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L80-R80): Updated the `tar` command to compress files from the `public/docs` directory instead of `docs/.vitepress/dist`, aligning with the updated file structure.

### Date Formatting in Meeting Form:

* [`resources/js/Components/AdminForms/MeetingForm.vue`](diffhunk://#diff-48e0d91beec6ebed3076c762a0ad21a252882c69d3d9d26b48eec92ac33b7862R157-R165): Modified the `onSubmit` function to format the `start_time` field in the local timezone without converting to UTC, ensuring consistency in date representation. This is achieved by creating a localized ISO string and replacing the `T` with a space.